### PR TITLE
use PREFIX also for CHROMIUM_BINARY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-PREFIX = /usr/local
+PREFIX ?= /usr
 
 CHROMIUM_SUFFIX  =
 CHROMIUM_NAME    = chromium$(CHROMIUM_SUFFIX)
-CHROMIUM_BINARY  = /usr/lib/$(CHROMIUM_NAME)/$(CHROMIUM_NAME)
+CHROMIUM_BINARY  = $(PREFIX)/lib/$(CHROMIUM_NAME)/$(CHROMIUM_NAME)
 CHROMIUM_VENDOR  = $(shell . /etc/os-release; echo $$NAME)
 
 override CFLAGS += $(shell pkg-config --cflags glib-2.0)


### PR DESCRIPTION
The easiest way to install a parallel ungoogled-chromium [PKGBUILD](https://aur.archlinux.org/packages/ungoogled-chromium/) into a system with chromium already installed is to change its PREFIX to somewhere else. I chose `/opt/ungoogled-chromium` but unfortunately this launcher which is packaged together is hardcoded to always look for the binary in its default location `/usr`